### PR TITLE
lazily download ruby toolchain

### DIFF
--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -61,10 +61,10 @@ rb_binary(
 ## rb_download
 
 <pre>
-rb_download(<a href="#rb_download-kwargs">kwargs</a>)
+rb_download(<a href="#rb_download-version">version</a>, <a href="#rb_download-kwargs">kwargs</a>)
 </pre>
 
-    Downloads an Ruby interpreter and registers it toolchain.
+    Register a Ruby toolchain and lazily download the Ruby Interpreter.
 
 * _(For MRI on Linux and macOS)_ Installed using [ruby-build](https://github.com/rbenv/ruby-build).
 * _(For MRI on Windows)_ Installed using [RubyInstaller](https://rubyinstaller.org).
@@ -85,6 +85,40 @@ rb_download(
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
+| <a id="rb_download-version"></a>version |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="rb_download-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
+<a id="rb_register_toolchains"></a>
+
+## rb_register_toolchains
+
+<pre>
+rb_register_toolchains(<a href="#rb_register_toolchains-version">version</a>, <a href="#rb_register_toolchains-kwargs">kwargs</a>)
+</pre>
+
+    Register a Ruby toolchain and lazily download the Ruby Interpreter.
+
+* _(For MRI on Linux and macOS)_ Installed using [ruby-build](https://github.com/rbenv/ruby-build).
+* _(For MRI on Windows)_ Installed using [RubyInstaller](https://rubyinstaller.org).
+* _(For JRuby on any OS)_ Downloaded and installed directly from [official website](https://www.jruby.org).
+* _(For TruffleRuby on Linux and macOS)_ Installed using [ruby-build](https://github.com/rbenv/ruby-build).
+
+`WORKSPACE`:
+```bazel
+load("@rules_ruby//ruby:deps.bzl", "rb_download")
+
+rb_download(
+    version = "2.7.5"
+)
+```
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="rb_register_toolchains-version"></a>version |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="rb_register_toolchains-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 

--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -64,21 +64,7 @@ rb_binary(
 rb_download(<a href="#rb_download-version">version</a>, <a href="#rb_download-kwargs">kwargs</a>)
 </pre>
 
-    Register a Ruby toolchain and lazily download the Ruby Interpreter.
-
-* _(For MRI on Linux and macOS)_ Installed using [ruby-build](https://github.com/rbenv/ruby-build).
-* _(For MRI on Windows)_ Installed using [RubyInstaller](https://rubyinstaller.org).
-* _(For JRuby on any OS)_ Downloaded and installed directly from [official website](https://www.jruby.org).
-* _(For TruffleRuby on Linux and macOS)_ Installed using [ruby-build](https://github.com/rbenv/ruby-build).
-
-`WORKSPACE`:
-```bazel
-load("@rules_ruby//ruby:deps.bzl", "rb_download")
-
-rb_download(
-    version = "2.7.5"
-)
-```
+    Alias for `rb_register_toolchains`.
 
 **PARAMETERS**
 
@@ -108,7 +94,7 @@ rb_register_toolchains(<a href="#rb_register_toolchains-version">version</a>, <a
 ```bazel
 load("@rules_ruby//ruby:deps.bzl", "rb_download")
 
-rb_download(
+rb_register_toolchains(
     version = "2.7.5"
 )
 ```

--- a/docs/repository_rules.md
+++ b/docs/repository_rules.md
@@ -56,25 +56,6 @@ rb_binary(
 | <a id="rb_bundle-srcs"></a>srcs |  List of Ruby source files used to build the library.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 
 
-<a id="rb_download"></a>
-
-## rb_download
-
-<pre>
-rb_download(<a href="#rb_download-version">version</a>, <a href="#rb_download-kwargs">kwargs</a>)
-</pre>
-
-    Alias for `rb_register_toolchains`.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="rb_download-version"></a>version |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="rb_download-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
-
-
 <a id="rb_register_toolchains"></a>
 
 ## rb_register_toolchains

--- a/examples/gem/WORKSPACE
+++ b/examples/gem/WORKSPACE
@@ -3,10 +3,10 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rb_bundle", "rb_download")
+load("@rules_ruby//ruby:deps.bzl", "rb_bundle", "rb_register_toolchains")
 load("ruby_version.bzl", "RUBY_VERSION")
 
-rb_download(
+rb_register_toolchains(
     ruby_build_version = "20230428",
     version = RUBY_VERSION,
 )

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -1,6 +1,5 @@
 load("//ruby/private:bundle.bzl", _rb_bundle = "rb_bundle")
-load("//ruby/private:download.bzl", _rb_download = "rb_download", _rb_register_toolchains = "rb_register_toolchains")
+load("//ruby/private:download.bzl", _rb_register_toolchains = "rb_register_toolchains")
 
 rb_bundle = _rb_bundle
 rb_register_toolchains = _rb_register_toolchains
-rb_download = _rb_download

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -1,6 +1,6 @@
 load("//ruby/private:bundle.bzl", _rb_bundle = "rb_bundle")
-load("//ruby/private:download.bzl", _rb_download = "rb_download")
+load("//ruby/private:download.bzl", _rb_download = "rb_download", _rb_register_toolchains = "rb_register_toolchains")
 
 rb_bundle = _rb_bundle
-rb_register_toolchains = _rb_download
-rb_download = _rb_download # backwards-compatibility
+rb_register_toolchains = _rb_register_toolchains
+rb_download = _rb_download

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -2,4 +2,5 @@ load("//ruby/private:bundle.bzl", _rb_bundle = "rb_bundle")
 load("//ruby/private:download.bzl", _rb_download = "rb_download")
 
 rb_bundle = _rb_bundle
-rb_download = _rb_download
+rb_register_toolchains = _rb_download
+rb_download = _rb_download # backwards-compatibility

--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -2,7 +2,7 @@ _JRUBY_BINARY_URL = "https://repo1.maven.org/maven2/org/jruby/jruby-dist/{versio
 _RUBY_BUILD_URL = "https://github.com/rbenv/ruby-build/archive/refs/tags/v{version}.tar.gz"
 _RUBY_INSTALLER_URL = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-{version}-1/rubyinstaller-devkit-{version}-1-x64.exe"
 
-def rb_download(version = None, **kwargs):
+def rb_register_toolchains(version = None, **kwargs):
     """
     Register a Ruby toolchain and lazily download the Ruby Interpreter.
 
@@ -15,7 +15,7 @@ def rb_download(version = None, **kwargs):
     ```bazel
     load("@rules_ruby//ruby:deps.bzl", "rb_download")
 
-    rb_download(
+    rb_register_toolchains(
         version = "2.7.5"
     )
     ```
@@ -30,6 +30,12 @@ def rb_download(version = None, **kwargs):
             toolchain_type = "@rules_ruby//ruby:toolchain_type",
         )
         native.register_toolchains("@{}//:all".format(proxy_repo_name))
+
+def rb_download(version = None, **kwargs):
+    """
+    Alias for `rb_register_toolchains`.
+    """
+    rb_register_toolchains(version = version, **kwargs)
 
 def _rb_toolchain_repository_proxy_impl(repository_ctx):
     repository_ctx.file(

--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -2,9 +2,9 @@ _JRUBY_BINARY_URL = "https://repo1.maven.org/maven2/org/jruby/jruby-dist/{versio
 _RUBY_BUILD_URL = "https://github.com/rbenv/ruby-build/archive/refs/tags/v{version}.tar.gz"
 _RUBY_INSTALLER_URL = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-{version}-1/rubyinstaller-devkit-{version}-1-x64.exe"
 
-def rb_download(**kwargs):
+def rb_download(version = None, **kwargs):
     """
-    Downloads an Ruby interpreter and registers it toolchain.
+    Register a Ruby toolchain and lazily download the Ruby Interpreter.
 
     * _(For MRI on Linux and macOS)_ Installed using [ruby-build](https://github.com/rbenv/ruby-build).
     * _(For MRI on Windows)_ Installed using [RubyInstaller](https://rubyinstaller.org).
@@ -20,11 +20,52 @@ def rb_download(**kwargs):
     )
     ```
     """
-    _rb_download(
-        name = "rules_ruby_dist",
-        **kwargs
+    repo_name = "rules_ruby_dist"
+    proxy_repo_name = "rules_ruby_toolchains"
+    if repo_name not in native.existing_rules().values():
+        _rb_download(name = repo_name, version = version, **kwargs)
+        rb_toolchain_repository_proxy(
+            name = proxy_repo_name,
+            toolchain = "@{}//:toolchain".format(repo_name),
+            toolchain_type = "@rules_ruby//ruby:toolchain_type",
+        )
+        native.register_toolchains("@{}//:all".format(proxy_repo_name))
+
+def _rb_toolchain_repository_proxy_impl(repository_ctx):
+    repository_ctx.file(
+        "WORKSPACE",
+        """workspace(name = "{}")""".format(repository_ctx.name)
     )
-    native.register_toolchains("@rules_ruby_dist//:toolchain")
+
+    build_file_template = """
+toolchain(
+    name = "{name}",
+    toolchain = "{toolchain}",
+    toolchain_type = "{toolchain_type}",
+    visibility = ["//visibility:public"],
+)
+"""
+    repository_ctx.file(
+        "BUILD",
+        build_file_template.format(
+            name = repository_ctx.attr.name,
+            toolchain = repository_ctx.attr.toolchain,
+            toolchain_type = repository_ctx.attr.toolchain_type,
+        ),
+        executable = False,
+    )
+
+rb_toolchain_repository_proxy = repository_rule(
+    implementation = _rb_toolchain_repository_proxy_impl,
+    attrs = {
+        "toolchain": attr.string(mandatory = True),
+        "toolchain_type": attr.string(mandatory = True),
+    },
+    doc = (
+        "A proxy repository that contains the toolchain declaration; this indirection " +
+        "allows the Ruby toolchain to be downloaded lazily."
+    )
+)
 
 def _rb_download_impl(repository_ctx):
     if repository_ctx.attr.version.startswith("jruby"):

--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -31,12 +31,6 @@ def rb_register_toolchains(version = None, **kwargs):
         )
         native.register_toolchains("@{}//:all".format(proxy_repo_name))
 
-def rb_download(version = None, **kwargs):
-    """
-    Alias for `rb_register_toolchains`.
-    """
-    rb_register_toolchains(version = version, **kwargs)
-
 def _rb_toolchain_repository_proxy_impl(repository_ctx):
     repository_ctx.file(
         "WORKSPACE",

--- a/ruby/private/download/BUILD.tpl
+++ b/ruby/private/download/BUILD.tpl
@@ -23,10 +23,6 @@ filegroup(
     srcs = ["dist/bin/{gem_binary_name}"],
 )
 
-toolchain_type(
-    name = "toolchain_type",
-)
-
 rb_toolchain(
     name = "toolchain",
     ruby = ":ruby",

--- a/ruby/toolchain.bzl
+++ b/ruby/toolchain.bzl
@@ -1,21 +1,3 @@
-def rb_toolchain(name, ruby, bundle, gem, bindir, version):
-    toolchain_name = "%s_toolchain" % name
-
-    _rb_toolchain(
-        name = toolchain_name,
-        ruby = ruby,
-        bundle = bundle,
-        gem = gem,
-        bindir = bindir,
-        version = version,
-    )
-
-    native.toolchain(
-        name = name,
-        toolchain = ":%s" % toolchain_name,
-        toolchain_type = "@rules_ruby//ruby:toolchain_type",
-    )
-
 def _rb_toolchain_impl(ctx):
     return platform_common.ToolchainInfo(
         ruby = ctx.executable.ruby,
@@ -25,7 +7,7 @@ def _rb_toolchain_impl(ctx):
         version = ctx.attr.version,
     )
 
-_rb_toolchain = rule(
+rb_toolchain = rule(
     implementation = _rb_toolchain_impl,
     attrs = {
         "ruby": attr.label(


### PR DESCRIPTION
Fixes https://github.com/p0deje/rules_ruby/issues/3.

Introduce a "proxy repository" to register the toolchain without actually downloading it.
