### PR TITLE
support `rb_binary` with Gemfiles in subdirectory

### DIFF
--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -38,7 +38,7 @@ Use a built-in `args` attribute to pass extra arguments to the script.
     ),
 }
 
-def get_relative_path_to_workspace_root(path):
+def get_relative_path_to_external(path):
     nest_level = len(path.split("/"))
     return "../" * nest_level
 
@@ -110,7 +110,7 @@ def rb_binary_impl(ctx):
         # TODO: Do not depend on workspace name to determine bundle
         if dep.label.workspace_name.endswith("bundle"):
             bundler = True
-            env["BUNDLE_PATH"] = get_relative_path_to_workspace_root(env["BUNDLE_GEMFILE"]) + dep.label.workspace_name
+            env["BUNDLE_PATH"] = get_relative_path_to_external(env["BUNDLE_GEMFILE"]) + dep.label.workspace_name
 
     runfiles = ctx.runfiles(transitive_data + transitive_srcs + tools)
     env.update(ctx.attr.env)

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -110,6 +110,8 @@ def rb_binary_impl(ctx):
         # TODO: Do not depend on workspace name to determine bundle
         if dep.label.workspace_name.endswith("bundle"):
             bundler = True
+            # temporary workaround for Gemfile in subdirectories because location of Gemfile
+            # sets the root of the project, which bundler uses to resolve relative paths
             env["BUNDLE_PATH"] = get_relative_path_to_external(env["BUNDLE_GEMFILE"]) + dep.label.workspace_name
 
     runfiles = ctx.runfiles(transitive_data + transitive_srcs + tools)

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -38,6 +38,10 @@ Use a built-in `args` attribute to pass extra arguments to the script.
     ),
 }
 
+def get_relative_path_to_workspace_root(path):
+    nest_level = len(path.split("/"))
+    return "../" * nest_level
+
 def generate_rb_binary_script(ctx, binary, bundler = False, args = []):
     windows_constraint = ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]
     is_windows = ctx.target_platform_has_constraint(windows_constraint)
@@ -106,7 +110,7 @@ def rb_binary_impl(ctx):
         # TODO: Do not depend on workspace name to determine bundle
         if dep.label.workspace_name.endswith("bundle"):
             bundler = True
-            env["BUNDLE_PATH"] = "../" + dep.label.workspace_name
+            env["BUNDLE_PATH"] = get_relative_path_to_workspace_root(env["BUNDLE_GEMFILE"]) + dep.label.workspace_name
 
     runfiles = ctx.runfiles(transitive_data + transitive_srcs + tools)
     env.update(ctx.attr.env)


### PR DESCRIPTION
Temporary workaround to support nested Gemfiles; a bit hacky since this expects a Gemfile in the transitive srcs. Ideally we'd want to provide this information via the rb_bundle repository rather than explicitly passing it in via `srcs`.