### PR TITLE
chore: automate releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# In code review, collapse generated files
+docs/*.md linguist-generated=true
+
+# Configuration for 'git archive'
+# see https://git-scm.com/docs/git-archive/2.40.0#ATTRIBUTES
+# Omit folders that users don't need, making the distribution artifact smaller
+examples export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+# Cut a release whenever a new tag is pushed to the repo.
+# You should use an annotated tag, like `git tag -a v1.2.3`
+# and put the release notes into the commit message for the tag.
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v5
+    with:
+      release_files: rules_ruby-*.tar.gz

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+# Set by GH actions, see
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+TAG=${GITHUB_REF_NAME}
+# The prefix is chosen to match what GitHub generates for source archives
+PREFIX="rules_ruby-${TAG:1}"
+ARCHIVE="rules_ruby-$TAG.tar.gz"
+
+# NB: configuration for 'git archive' is in /.gitattributes
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
+
+# The stdout of this program will be used as the top of the release notes for this release.
+cat << EOF
+## Using Bzlmod with Bazel 6
+
+TODO: https://github.com/p0deje/rules_ruby/issues/12
+
+## Using WORKSPACE
+
+Paste this snippet into your \`WORKSPACE.bazel\` file:
+
+\`\`\`starlark
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "rules_ruby",
+    sha256 = "${SHA}",
+    strip_prefix = "${PREFIX}",
+    url = "https://github.com/p0deje/rules_ruby/releases/download/${TAG}/${ARCHIVE}",
+)
+\`\`\`
+EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# How to Contribute
+
+TODO
+
+## Releasing
+
+To perform a release, simply tag the commit you wish to release, for example:
+
+```
+rules_ruby$ git fetch
+rules_ruby$ git tag v1.2.3 origin/main
+rules_ruby$ git push origin v1.2.3
+```


### PR DESCRIPTION
It's now sufficient to just push a tag to the repository, this will create a release using GitHub actions with reasonable release notes, and it also uses a release artifact since GitHub doesn't guarantee stability of their archives.

This is taken from the https://github.com/bazel-contrib/rules-template which is maintained by experts on the Rules Authors SIG to make rules easy to maintain and also more consistent.