### PR TITLE
chore: introduce buildifier format/linter for starlark

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# See CONTRIBUTING.md for instructions.
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  # Check formatting and lint for starlark code
+  - repo: https://github.com/keith/pre-commit-buildifier
+    rev: 6.3.3
+    hooks:
+      - id: buildifier
+      - id: buildifier-lint

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -2,14 +2,14 @@ load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 stardoc(
     name = "rules",
-    input = "//ruby:defs.bzl",
     out = "rules.md",
-    deps = ["//:ruby"]
+    input = "//ruby:defs.bzl",
+    deps = ["//:ruby"],
 )
 
 stardoc(
     name = "repository_rules",
     out = "repository_rules.md",
     input = "//ruby:deps.bzl",
-    deps = ["//:ruby"]
+    deps = ["//:ruby"],
 )

--- a/examples/gem/ruby_version.bzl
+++ b/examples/gem/ruby_version.bzl
@@ -1,1 +1,2 @@
+"Provide a default version of an interpreter used for the example"
 RUBY_VERSION = "3.2.1"

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -1,3 +1,5 @@
+"Public API for rules"
+
 load("//ruby/private:binary.bzl", _rb_binary = "rb_binary")
 load("//ruby/private:gem_build.bzl", _rb_gem_build = "rb_gem_build")
 load("//ruby/private:gem_push.bzl", _rb_gem_push = "rb_gem_push")

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -1,3 +1,5 @@
+"Public API for repository rules"
+
 load("//ruby/private:bundle.bzl", _rb_bundle = "rb_bundle")
 load("//ruby/private:download.bzl", _rb_register_toolchains = "rb_register_toolchains")
 

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -1,11 +1,13 @@
+"Implementation details for rb_binary"
+
 load("//ruby/private:library.bzl", LIBRARY_ATTRS = "ATTRS")
 load(
     "//ruby/private:providers.bzl",
     "RubyFilesInfo",
+    "get_bundle_env",
     "get_transitive_data",
     "get_transitive_deps",
     "get_transitive_srcs",
-    "get_bundle_env",
 )
 
 ATTRS = {
@@ -39,6 +41,7 @@ Use a built-in `args` attribute to pass extra arguments to the script.
     ),
 }
 
+# buildifier: disable=function-docstring
 def generate_rb_binary_script(ctx, binary, bundler = False, args = []):
     windows_constraint = ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]
     is_windows = ctx.target_platform_has_constraint(windows_constraint)
@@ -82,6 +85,7 @@ def generate_rb_binary_script(ctx, binary, bundler = False, args = []):
 
     return script
 
+# buildifier: disable=function-docstring
 def rb_binary_impl(ctx):
     bundler = False
     env = {}

--- a/ruby/private/bundle.bzl
+++ b/ruby/private/bundle.bzl
@@ -1,3 +1,5 @@
+"Implementation details for calling the bundler"
+
 # https://github.com/rubygems/rubygems/blob/f8c76eae24bbeabb9c9cb5387dbd89df45566eb9/bundler/lib/bundler/installer.rb#L147
 _BINSTUB_CMD = """@ruby -x "%~f0" %*
 @exit /b %ERRORLEVEL%

--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -1,3 +1,4 @@
+"Repository rule for fetching Ruby interpreters"
 _JRUBY_BINARY_URL = "https://repo1.maven.org/maven2/org/jruby/jruby-dist/{version}/jruby-dist-{version}-bin.tar.gz"
 _RUBY_BUILD_URL = "https://github.com/rbenv/ruby-build/archive/refs/tags/v{version}.tar.gz"
 _RUBY_INSTALLER_URL = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-{version}-1/rubyinstaller-devkit-{version}-1-x64.exe"
@@ -19,6 +20,10 @@ def rb_register_toolchains(version = None, **kwargs):
         version = "2.7.5"
     )
     ```
+
+    Args:
+        version: a semver version of Matz Ruby Interpreter, or a string like [interpreter type]-[version]
+        **kwargs: additional parameters to the downloader for this interpreter type
     """
     repo_name = "rules_ruby_dist"
     proxy_repo_name = "rules_ruby_toolchains"

--- a/ruby/private/gem_build.bzl
+++ b/ruby/private/gem_build.bzl
@@ -1,11 +1,13 @@
+"Implementation details for rb_gem_build"
+
 load("//ruby/private:library.bzl", LIBRARY_ATTRS = "ATTRS")
 load(
     "//ruby/private:providers.bzl",
     "RubyFilesInfo",
+    "get_bundle_env",
     "get_transitive_data",
     "get_transitive_deps",
     "get_transitive_srcs",
-    "get_bundle_env",
 )
 
 def _rb_gem_build_impl(ctx):

--- a/ruby/private/gem_push.bzl
+++ b/ruby/private/gem_push.bzl
@@ -1,3 +1,5 @@
+"Implementation details for gem_push"
+
 load("//ruby/private:binary.bzl", "generate_rb_binary_script", BINARY_ATTRS = "ATTRS")
 load("//ruby/private:library.bzl", LIBRARY_ATTRS = "ATTRS")
 

--- a/ruby/private/library.bzl
+++ b/ruby/private/library.bzl
@@ -1,10 +1,12 @@
+"Implementation details for rb_library"
+
 load(
     "//ruby/private:providers.bzl",
     "RubyFilesInfo",
+    "get_bundle_env",
     "get_transitive_data",
     "get_transitive_deps",
     "get_transitive_srcs",
-    "get_bundle_env",
 )
 
 ATTRS = {

--- a/ruby/private/providers.bzl
+++ b/ruby/private/providers.bzl
@@ -1,3 +1,4 @@
+"Providers for Interoperability between rules"
 RubyFilesInfo = provider(
     "Provider for Ruby files",
     fields = ["transitive_data", "transitive_deps", "transitive_srcs", "bundle_env"],
@@ -47,22 +48,22 @@ def get_transitive_deps(deps):
     )
 
 def get_bundle_env(envs, deps):
-  """Obtain the BUNDLE_* environment variables for a target and its transitive dependencies.
+    """Obtain the BUNDLE_* environment variables for a target and its transitive dependencies.
 
-  Args:
-    envs: a list of environment variables
-    deps: a list of targets that are direct dependencies
-  Returns:
-    a collection of the transitive environment variables
-  """
-  bundle_env = {}
+    Args:
+      envs: a list of environment variables
+      deps: a list of targets that are direct dependencies
+    Returns:
+      a collection of the transitive environment variables
+    """
+    bundle_env = {}
 
-  transitive_deps = get_transitive_deps(deps).to_list()
-  for dep in transitive_deps:
-    bundle_env.update(dep[RubyFilesInfo].bundle_env)
+    transitive_deps = get_transitive_deps(deps).to_list()
+    for dep in transitive_deps:
+        bundle_env.update(dep[RubyFilesInfo].bundle_env)
 
-  for env in envs:
-    if env.startswith("BUNDLE_"):
-      bundle_env[env] = envs[env]
+    for env in envs:
+        if env.startswith("BUNDLE_"):
+            bundle_env[env] = envs[env]
 
-  return bundle_env
+    return bundle_env

--- a/ruby/private/test.bzl
+++ b/ruby/private/test.bzl
@@ -1,3 +1,5 @@
+"Implementation details for rb_test"
+
 load("//ruby/private:binary.bzl", "ATTRS", "rb_binary_impl")
 load("//ruby/private:library.bzl", LIBRARY_ATTRS = "ATTRS")
 

--- a/ruby/toolchain.bzl
+++ b/ruby/toolchain.bzl
@@ -1,3 +1,5 @@
+"Define a Bazel toolchain for a Ruby interpreter"
+
 def _rb_toolchain_impl(ctx):
     return platform_common.ToolchainInfo(
         ruby = ctx.executable.ruby,


### PR DESCRIPTION
So far this is just opt-in, you install from pre-commit.com and run 'pre-commit install' to get your commits formatted nicely. We can add some CI enforcement for this in a follow-up PR.

Ran 'pre-commit run --all-files' to do an initial pass over the repo and made it warning-clean.