### PR TITLE
chore: add a test that documentation stays updated

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: p0deje/setup-bazel@0.1.0
-      - run: bazel test ...
-        working-directory: .
       - run: echo 'RUBY_VERSION = "${{ matrix.ruby }}"' > ruby_version.bzl
       - run: bazel build ...
       - run: bazel run lib/gem:add-numbers 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: p0deje/setup-bazel@0.1.0
+      - run: bazel test ...
+        working-directory: .
       - run: echo 'RUBY_VERSION = "${{ matrix.ruby }}"' > ruby_version.bzl
       - run: bazel build ...
       - run: bazel run lib/gem:add-numbers 2
@@ -43,10 +45,3 @@ jobs:
       - run: bazel test ...
       - if: failure() && runner.debug == '1'
         uses: mxschmitt/action-tmate@v3
-
-  stardoc:
-    name: Stardoc
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: bazel build docs/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,10 @@ jobs:
       - run: bazel test ...
       - if: failure() && runner.debug == '1'
         uses: mxschmitt/action-tmate@v3
+        
+  ruleset:
+    name: Ruleset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: bazel test ...

--- a/BUILD
+++ b/BUILD
@@ -1,20 +1,11 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 
-package(default_visibility = ["//:__subpackages__"])
+gazelle_binary(
+    name = "gazelle_bin",
+    languages = ["@bazel_skylib_gazelle_plugin//bzl"],
+)
 
-bzl_library(
-    name = "ruby",
-    srcs = [
-        "//ruby:defs.bzl",
-        "//ruby:deps.bzl",
-        "//ruby:toolchain.bzl",
-        "//ruby/private:binary.bzl",
-        "//ruby/private:bundle.bzl",
-        "//ruby/private:download.bzl",
-        "//ruby/private:gem_build.bzl",
-        "//ruby/private:gem_push.bzl",
-        "//ruby/private:library.bzl",
-        "//ruby/private:providers.bzl",
-        "//ruby/private:test.bzl",
-    ],
+gazelle(
+    name = "gazelle",
+    gazelle = "gazelle_bin",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,3 +27,49 @@ http_archive(
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
+
+############################################
+# Gazelle, for generating bzl_library targets
+
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "4b32cf6feab38b887941db022020eea5a49b848e11e3d6d4d18433594951717a",
+    strip_prefix = "bazel-lib-2.0.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz",
+)
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "d3fa66a39028e97d76f9e2db8f1b0c11c099e8e01bf363a923074784e451f809",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "bazel_skylib_gazelle_plugin",
+    sha256 = "3327005dbc9e49cc39602fb46572525984f7119a9c6ffe5ed69fbe23db7c1560",
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-gazelle-plugin-1.4.2.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.18.3")
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,15 +1,15 @@
-load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+# This load statement must be in the docs/ package rather than anything users depend on
+# so that the dependency on stardoc doesn't leak to them.
+load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
 
-stardoc(
+stardoc_with_diff_test(
     name = "rules",
-    input = "//ruby:defs.bzl",
-    out = "rules.md",
-    deps = ["//:ruby"]
+    bzl_library_target = "//ruby:defs",
 )
 
-stardoc(
+stardoc_with_diff_test(
     name = "repository_rules",
-    out = "repository_rules.md",
-    input = "//ruby:deps.bzl",
-    deps = ["//:ruby"]
+    bzl_library_target = "//ruby:deps",
 )
+
+update_docs(name = "update")

--- a/examples/gem/WORKSPACE
+++ b/examples/gem/WORKSPACE
@@ -3,6 +3,16 @@ local_repository(
     path = "../..",
 )
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+    ],
+)
+
 load("@rules_ruby//ruby:deps.bzl", "rb_bundle", "rb_register_toolchains")
 load("ruby_version.bzl", "RUBY_VERSION")
 

--- a/ruby/BUILD
+++ b/ruby/BUILD
@@ -1,6 +1,36 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ["//visibility:public"])
+
 exports_files(glob(["*.bzl"]))
 
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    deps = [
+        "//ruby/private:binary",
+        "//ruby/private:gem_build",
+        "//ruby/private:gem_push",
+        "//ruby/private:library",
+        "//ruby/private:test",
+    ],
+)
+
+bzl_library(
+    name = "deps",
+    srcs = ["deps.bzl"],
+    deps = [
+        "//ruby/private:bundle",
+        "//ruby/private:download",
+    ],
+)
+
+bzl_library(
+    name = "toolchain",
+    srcs = ["toolchain.bzl"],
 )

--- a/ruby/private/BUILD
+++ b/ruby/private/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 exports_files([
     "binary/binary.cmd.tpl",
     "binary/binary.sh.tpl",
@@ -5,3 +7,68 @@ exports_files([
 ])
 
 exports_files(glob(["**/*.bzl"]))
+
+bzl_library(
+    name = "binary",
+    srcs = ["binary.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+    deps = [
+        ":library",
+        ":providers",
+    ],
+)
+
+bzl_library(
+    name = "bundle",
+    srcs = ["bundle.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+)
+
+bzl_library(
+    name = "download",
+    srcs = ["download.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+)
+
+bzl_library(
+    name = "gem_build",
+    srcs = ["gem_build.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+    deps = [
+        ":library",
+        ":providers",
+    ],
+)
+
+bzl_library(
+    name = "gem_push",
+    srcs = ["gem_push.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+    deps = [
+        ":binary",
+        ":library",
+    ],
+)
+
+bzl_library(
+    name = "library",
+    srcs = ["library.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+    deps = [":providers"],
+)
+
+bzl_library(
+    name = "providers",
+    srcs = ["providers.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+)
+
+bzl_library(
+    name = "test",
+    srcs = ["test.bzl"],
+    visibility = ["//ruby:__subpackages__"],
+    deps = [
+        ":binary",
+        ":library",
+    ],
+)


### PR DESCRIPTION
If I understand correctly, the stardoc job on CI was just building docs, but not checking that they were updated. for example, https://github.com/p0deje/rules_ruby/actions/runs/6911195706/job/18805400388?pr=18

This PR follows the pattern from the https://github.com/bazel-contrib/rules-template to manage docgen.

Also, the bzl_library at the root needed manual updates, and includes all starlark in the repo, which isn't quite how it was meant to be used. This PR does mean that users will have to install bazel_skylib in their own WORKSPACE file, but this is a very common requirement among all major Bazel rulesets. The `//:gazelle` target added here automates the work of keeping the bzl_library targets current, so this shouldn't slow us down as we work.