### PR TITLE
chore: extend timeout for some tests

### DIFF
--- a/examples/gem/spec/BUILD
+++ b/examples/gem/spec/BUILD
@@ -14,6 +14,7 @@ rb_library(
 rb_test(
     name = "add",
     size = "small",
+    timeout = "moderate",
     srcs = ["add_spec.rb"],
     args = ["spec/add_spec.rb"],
     main = "@bundle//:bin/rspec",
@@ -22,6 +23,7 @@ rb_test(
 
 rb_test(
     name = "env",
+    timeout = "moderate",
     size = "small",
     srcs = ["env_spec.rb"],
     args = ["spec/env_spec.rb"],
@@ -36,6 +38,7 @@ rb_test(
 
 rb_test(
     name = "file",
+    timeout = "moderate",
     size = "small",
     srcs = ["file_spec.rb"],
     args = ["spec/file_spec.rb"],


### PR DESCRIPTION
These made the latest main build red: https://github.com/p0deje/rules_ruby/actions/runs/6909216318/job/18800385795 Moderate timeout will give them 5min rather than 1min to complete.

Note, #18 will add buildifier which will sort these new attributes, so I didn't take any care what order they appear in.