### PR TITLE
chore: check buildifier on CI

### DIFF
--- a/.github/workflows/BUILD.bazel
+++ b/.github/workflows/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier.check",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "warn",
+    mode = "diff",
+)

--- a/.github/workflows/buildifier.yaml
+++ b/.github/workflows/buildifier.yaml
@@ -1,0 +1,19 @@
+name: Buildifier
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: buildifier
+        run: bazel run //.github/workflows:buildifier.check

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,3 +27,21 @@ http_archive(
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
+
+# Buildifier, used in CI to verify BUILD/.bzl files are formatted and linted
+http_archive(
+    name = "buildifier_prebuilt",
+    sha256 = "72b5bb0853aac597cce6482ee6c62513318e7f2c0050bc7c319d75d03d8a3875",
+    strip_prefix = "buildifier-prebuilt-6.3.3",
+    urls = [
+        "http://github.com/keith/buildifier-prebuilt/archive/6.3.3.tar.gz",
+    ],
+)
+
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
+
+buildifier_prebuilt_deps()
+
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()


### PR DESCRIPTION
Matches how it's done in the bazel-contrib/rules-template