### PR TITLE
chore: include examples in release artifact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,2 @@
 # In code review, collapse generated files
 docs/*.md linguist-generated=true
-
-# Configuration for 'git archive'
-# see https://git-scm.com/docs/git-archive/2.40.0#ATTRIBUTES
-# Omit folders that users don't need, making the distribution artifact smaller
-examples export-ignore


### PR DESCRIPTION
This is needed since we use the examples/gem folder as our artifact test on the bazel-central-registry presubmit.